### PR TITLE
Address clippy warnings, remove trailing semicolon in macro

### DIFF
--- a/newtype-enum/src/lib.rs
+++ b/newtype-enum/src/lib.rs
@@ -225,7 +225,7 @@ pub trait Enum: Sized {
     /// assert_eq!(test, Test::Str("Hello World"));
     /// # }
     /// ```
-    #[must_use]
+    #[allow(clippy::return_self_not_must_use)]
     fn set_variant(&mut self, v: impl Variant<Self>) -> Self {
         core::mem::replace(self, v.into_enum())
     }

--- a/newtype-enum/src/lib.rs
+++ b/newtype-enum/src/lib.rs
@@ -225,8 +225,9 @@ pub trait Enum: Sized {
     /// assert_eq!(test, Test::Str("Hello World"));
     /// # }
     /// ```
+    #[must_use]
     fn set_variant(&mut self, v: impl Variant<Self>) -> Self {
-        ::core::mem::replace(self, v.into_enum())
+        core::mem::replace(self, v.into_enum())
     }
 
     /// Convert the enum into one of its newtype variants.

--- a/newtype-enum/src/unstable.rs
+++ b/newtype-enum/src/unstable.rs
@@ -3,7 +3,6 @@
 //! All traits and types in this module are unstable. They could change in the future.
 
 use crate::Enum;
-use core::hint::unreachable_unchecked;
 
 /// Mark a type as a newtype variant of an [`Enum`](../trait.Enum.html) `E`.
 ///
@@ -37,21 +36,21 @@ pub trait VariantCore<E: Enum>: Sized {
     /// Implementors **should** write this method without an intermediate `Option<V>` value.
     /// This sometimes allows the compiler to optimize the code better.
     fn from_enum_unwrap(e: E) -> Self {
-        Self::from_enum(e).map_or_else(|| panic!("called `Variant::from_enum_unwrap` on another enum variant"), |v| v)
+        Self::from_enum(e).expect("called `Variant::from_enum_unwrap` on another enum variant")
     }
 
     /// Convert an enum into this newtype variant.
     unsafe fn from_enum_unchecked(e: E) -> Self {
-        Self::from_enum(e).map_or_else(|| unreachable_unchecked(), |v| v)
+        Self::from_enum(e).unwrap_unchecked()
     }
 
     /// Get a reference to this this newtype variant.
     unsafe fn ref_enum_unchecked(e: &E) -> &Self {
-        Self::ref_enum(e).map_or_else(|| unreachable_unchecked(), |v| v)
+        Self::ref_enum(e).unwrap_unchecked()
     }
 
     /// Get a mutable reference to this this newtype variant.
     unsafe fn mut_enum_unchecked(e: &mut E) -> &mut Self {
-        Self::mut_enum(e).map_or_else(|| unreachable_unchecked(), |v| v)
+        Self::mut_enum(e).unwrap_unchecked()
     }
 }

--- a/newtype-enum/src/unstable.rs
+++ b/newtype-enum/src/unstable.rs
@@ -37,33 +37,21 @@ pub trait VariantCore<E: Enum>: Sized {
     /// Implementors **should** write this method without an intermediate `Option<V>` value.
     /// This sometimes allows the compiler to optimize the code better.
     fn from_enum_unwrap(e: E) -> Self {
-        match Self::from_enum(e) {
-            Some(v) => v,
-            None => panic!("called `Variant::from_enum_unwrap` on another enum variant"),
-        }
+        Self::from_enum(e).map_or_else(|| panic!("called `Variant::from_enum_unwrap` on another enum variant"), |v| v)
     }
 
     /// Convert an enum into this newtype variant.
     unsafe fn from_enum_unchecked(e: E) -> Self {
-        match Self::from_enum(e) {
-            Some(v) => v,
-            None => unreachable_unchecked(),
-        }
+        Self::from_enum(e).map_or_else(|| unreachable_unchecked(), |v| v)
     }
 
     /// Get a reference to this this newtype variant.
     unsafe fn ref_enum_unchecked(e: &E) -> &Self {
-        match Self::ref_enum(e) {
-            Some(v) => v,
-            None => unreachable_unchecked(),
-        }
+        Self::ref_enum(e).map_or_else(|| unreachable_unchecked(), |v| v)
     }
 
     /// Get a mutable reference to this this newtype variant.
     unsafe fn mut_enum_unchecked(e: &mut E) -> &mut Self {
-        match Self::mut_enum(e) {
-            Some(v) => v,
-            None => unreachable_unchecked(),
-        }
+        Self::mut_enum(e).map_or_else(|| unreachable_unchecked(), |v| v)
     }
 }


### PR DESCRIPTION
This pull request addresses issue #1 